### PR TITLE
Fix bug in right-hand-side border values

### DIFF
--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -81,4 +81,21 @@ describe('Savitzky–Golay', () => {
       expect(ans[j]).toBeCloseTo(ans2[j], 10);
     }
   });
+
+  it('Border test', () => {
+    let options = {
+      windowSize: 9,
+      derivative: 1,
+      polynomial: 3,
+    };
+
+    let data = new Array(20);
+    for (let i = 0; i < data.length; i++) {
+      data[i] = Math.pow(i, 3) - 4 * Math.pow(i, 2) + 5 * i;
+    }
+    let ans = SG(data, 1, options);
+    for (let j = 0; j < data.length; j++) {
+      expect(ans[j]).toBeCloseTo(3 * Math.pow(j, 2) - 8 * j + 5, 6);
+    }
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ export default function SavitzkyGolay(data, h, options = {}) {
     let d2 = 0;
     for (let l = 0; l < windowSize; l++) {
       d1 += wg1[l] * data[l];
-      d2 += wg2[l] * data[np - windowSize + l - 1];
+      d2 += wg2[l] * data[np - windowSize + l];
     }
     if (constantH) {
       ans[half - i - 1] = d1 / hs;


### PR DESCRIPTION
Added a test: a degree-3 polynomial is fit to degree-3 data, so the returned values should be (almost) exact. This test checks the border values - i.e., those from `(windowSize - 1) / 2` from either end of the output. The border values are not covered by any of the existing tests.

NB: these values are intended to be produced by fitting a degree-`polynomial` polynomial to the first (or last) `windowSize` points and using that polynomial to evaluate each of the first (or last) `(windowSize - 1) / 2` points.

Fixed an off-by-one error which caused the last (a.k.a. right-hand-side) `(windowSize - 1) / 2` points to be calculated incorrectly.